### PR TITLE
Enable GoMetaLinter on save

### DIFF
--- a/go.vim
+++ b/go.vim
@@ -9,7 +9,7 @@ let g:go_highlight_structs = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
 let g:go_fmt_command = "goimports"
-
+let g:go_metalinter_autosave = 1
 
 
 augroup FileType go
@@ -30,4 +30,5 @@ augroup FileType go
   au FileType go nmap <Leader><leader>s <Plug>(go-implements)
   au FileType go nmap <Leader><leader>i <Plug>(go-info)
 augroup END
+
 


### PR DESCRIPTION
As stated here https://github.com/fatih/vim-go-tutorial#check-it there is a simple way to enable GoMetaLinter on save. 


No more excuse to not document the code! 