### PR TITLE
Run Gometalinter with SPC-SPC-l

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 plugged/*
 private.vim
+bundle
+spell
+autoload
+.netrwhist

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This configuration attempts to be battery included and maintain proper documenta
 | Compile | `SPC SPC c` | |
 | Run test | `SPC SPC t` | |
 | Show coverage | `SPC SPC o` | |
+| Run linters | `SPC SPC l` | |
 | Go to definition | `SPC SPC d#` | Where `#` can be `s` for a split, `v` for a vertical split, `t` for a tab |
 | Go to doc | `SPC SPC gd` | `SPC SPC gs` and `SPC SPC gv` for split or vertical split|
 | Go to doc in browser | `SPC SPC gb` | |

--- a/go.vim
+++ b/go.vim
@@ -10,7 +10,8 @@ let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
 let g:go_fmt_command = "goimports"
 let g:go_metalinter_autosave = 1
-
+let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck', 'deadcode']
+let g:go_metalinter_autosave_enabled = ['vet', 'golint']
 
 augroup FileType go
   au!
@@ -21,6 +22,7 @@ augroup FileType go
   au FileType go nmap <leader><leader>c <Plug>(go-build)
   au FileType go nmap <leader><leader>t <Plug>(go-test)
   au FileType go nmap <leader><leader>o <Plug>(go-coverage)
+  au FileType go nmap <leader><leader>l <Plug>(go-metalinter)
   au FileType go nmap <Leader><leader>ds <Plug>(go-def-split)
   au FileType go nmap <Leader><leader>dv <Plug>(go-def-vertical)
   au FileType go nmap <Leader><leader>dt <Plug>(go-def-tab)


### PR DESCRIPTION
Currently gometalinter runs on save with the following checks: `vet, golint`. 

This operation is fast enough to be run on each save.

However it is interesting to have more checks to run when one desires to. This PR adds support for this. 

From now on `SPC-SPC-l` gometalinter will run with `vet, golint, errcheck, deadcode`. 

This operation takes  longer though. 

