### PR TITLE
Prefix checkout path with ~/

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This configuration attempts to be battery included and maintain proper documenta
 ## Installation
 
 - Install neovim (available in Homebrew)
-- `git clone git://github.com/heetch/neovim-config .config/nvim`
+- `git clone git://github.com/heetch/neovim-config ~/.config/nvim`
 - `pip3 install neovim` (required by (deoplete.nvim) which powers autocompletion [https://github.com/Shougo/deoplete.nvim])
 - `nvim`
 - Type `:PlugInstall` to install all the required plugins.


### PR DESCRIPTION
I dumbly copy-pasted the the `git clone` command while my current path was `~/.config`, ending up checking out the config in the wrong place. This should prevent people from doing the same mistake.