### PR TITLE
Use 'ag -g ""' for fzf when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Once an enjoyable one is found:
 - `nvim ~/.config/nvim/private.vim`
 - Look for `colorscheme jellybeans` and replace it with the new one.
 
-### Optional steps
-
-- Set `export FZF_DEFAULT_COMMAND='ag -g ""'` in your shell profile to speed up file finder
-
 ## Cheatsheet
 
 Press `SPC ?` to display this cheatsheet.
@@ -76,7 +72,7 @@ Press `SPC ?` to display this cheatsheet.
 |----------|--------|-------------|
 | Show project drawer | `SPC -` | Toggle project drawer |
 | Open a file relatively to current buffer | `SPC e` | |
-| Fuzzy find a file in current project | `SPC f` | |
+| Fuzzy find a file in current project | `SPC f` | When [`ag`](https://github.com/ggreer/the_silver_searcher) is installed on your machine, only lists files not ignored by `.gitignore`, `.hgignore` and `.agignore` |
 | Find in project | `SPC F` | Find occurences of query in every files |
 | Find tags in project | `SPC t` | |
 

--- a/navigation.vim
+++ b/navigation.vim
@@ -60,6 +60,9 @@ map <Leader>= :Goyo<CR>
 map <silent> <Leader><CR> :Buffers<CR>
 
 " Fuzzy finder
+if executable("ag") " when installed, use 'ag -g' as the default fzf command
+  let $FZF_DEFAULT_COMMAND = 'ag -g ""'
+endif
 map <silent> <Leader>f :FZF<CR>
 
 " Find in project


### PR DESCRIPTION
Makes `<leader>f` really faster. Conditionally sets the default fzf command to use `ag`, which will ignore files ignored from `.gitignore`, `.hgignore` and `.agignore`.