### PR TITLE
Fix binding syntax for clearing search highlight

### DIFF
--- a/navigation.vim
+++ b/navigation.vim
@@ -39,7 +39,7 @@ nmap <Leader>- :NERDTreeToggle<CR>
 nmap <silent><Leader>%y :!echo % \| pbcopy<CR>
 
 " Clean search
-map //  :nohlsearch<CR>; echo 'Search highlight cleared' <CR>
+map //  :nohlsearch<CR>:echo 'Search highlight cleared'<CR>
 
 " Fix Quickfix showing in the tagbar
 "augroup tagbar-quickfix


### PR DESCRIPTION
I guess a typo slipped on this one, binding was using a semi-colon in place of a full one.

---

I want to also use this PR to mention I have this in my `private.vim`

    map <cr> :nohlsearch<CR>:echo 'Search highlight cleared'<CR>