### PR TITLE
Add VimWiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Press `SPC ?` to display this cheatsheet.
 |----------|--------|-------------|
 | Indent buffer | `SPC =` | equivalent to `ggVG=` |
 | Enable spell checking | `SPC c` | Fuzzy find through opened buffers |
+| Open VimWiki  | `SPC Wt` | Open VimWiki in a new Tab. SPC W is the prefix for every other vim wiki commands |
 
 ### Pair Programming
 

--- a/dependencies.vim
+++ b/dependencies.vim
@@ -18,7 +18,7 @@ Plug 'Shougo/neosnippet'
 Plug 'Shougo/neosnippet-snippets'
 
 " Misc
-Plug 'jceb/vim-orgmode'
+Plug 'vimwiki/vimwiki'
 
 " UI
 Plug 'tpope/vim-eunuch'

--- a/navigation.vim
+++ b/navigation.vim
@@ -101,3 +101,6 @@ inoremap <C-l> <C-x><C-l>
 
 " Stop concealing characters when going into navigation and edition mode
 set concealcursor=nc
+
+" VimWiki
+let g:vimwiki_map_prefix = '<Leader>W'


### PR DESCRIPTION
Add support for vim wiki, with `<leader>W` as a base prefix. So use `SPC Wt` to open the wiki in a new tab. 

See http://vimwiki.github.io/ for more info.

Basically it can be used to stored anything, from todo lists (with bindings to mark stuff as complete, etc ...) 