### PR TITLE
swift.vim configuration file

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -121,6 +121,7 @@ source ~/.config/nvim/ruby.vim
 source ~/.config/nvim/make.vim
 source ~/.config/nvim/python.vim
 source ~/.config/nvim/go.vim
+source ~/.config/nvim/swift.vim
 
 source ~/.config/nvim/git.vim
 source ~/.config/nvim/ui.vim

--- a/swift.vim
+++ b/swift.vim
@@ -1,0 +1,1 @@
+au FileType swift set conceallevel=0


### PR DESCRIPTION
- create `swift.vim`
- source it
- set `conceallevel` to 0 to prevent vim from hiding special character combinations (`<|>` was transformed into `<`)
    :arrow_up: This may very well deserve to be set in the global configuration file, but I'm not sure if it would clash with some filetypes (thinking mostly of `json`)